### PR TITLE
Fix dialogue trigger not properly triggering again for the same object

### DIFF
--- a/Assets/Core/InteractionBasic/PlayerActivatable.cs
+++ b/Assets/Core/InteractionBasic/PlayerActivatable.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using Yarn.Unity;
 using System;
 
-[RequireComponent(typeof(Collider))]
 public abstract class PlayerActivatable : MonoBehaviour
 {
     public bool canRepeat = false;

--- a/Assets/Core/InteractionBasic/PlayerActivatable.cs
+++ b/Assets/Core/InteractionBasic/PlayerActivatable.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Yarn.Unity;
 using System;
 
+[RequireComponent(typeof(Collider))]
 public abstract class PlayerActivatable : MonoBehaviour
 {
     public bool canRepeat = false;

--- a/Assets/Core/InteractionBasic/TriggerPlayerActivatables.cs
+++ b/Assets/Core/InteractionBasic/TriggerPlayerActivatables.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-[RequireComponent(typeof(CharacterController))]
+[RequireComponent(typeof(CharacterController), typeof(Rigidbody))]
 public class TriggerPlayerActivatables : MonoBehaviour
 {
     private HashSet<PlayerActivatable> _previousHits = new HashSet<PlayerActivatable>();
@@ -10,16 +10,14 @@ public class TriggerPlayerActivatables : MonoBehaviour
     void Awake() {
         // Ensure a Rigidbody component is present and set it to kinematic
         Rigidbody rb = GetComponent<Rigidbody>();
-        if (rb == null) {
-            rb = gameObject.AddComponent<Rigidbody>();
-        }
+        if (!rb.isKinematic) return;
+        Debug.LogWarning($"{gameObject.name} Trigger Player Activatables is using a non-kinematic rigidbody. It will be forcibly set to kinematic.");
         rb.isKinematic = true;
     }
 
     void Update()
     {
         if (_currentHits.Count == 0) return;
-
         foreach (PlayerActivatable playerActivatable in _currentHits) {
             if (!_previousHits.Contains(playerActivatable)) {
                 playerActivatable.OnColliding();
@@ -34,8 +32,19 @@ public class TriggerPlayerActivatables : MonoBehaviour
         _currentHits.Clear();
     }
 
-    void OnControllerColliderHit(ControllerColliderHit hit) {
-        HandleCollision(hit.gameObject);
+    void OnControllerColliderHit(ControllerColliderHit hit)
+    {
+        IterateOverPlayerActivatables(hit.gameObject.GetComponents<PlayerActivatable>());
+    }
+
+    private void IterateOverPlayerActivatables(PlayerActivatable[] playerActivatables)
+    {
+        if (playerActivatables == null) return;
+        foreach (PlayerActivatable playerActivatable in playerActivatables) {
+            if (!_previousHits.Contains(playerActivatable)) {
+                playerActivatable.OnColliding();
+            }
+        }
     }
 
     void OnTriggerEnter(Collider other) {
@@ -62,7 +71,7 @@ public class TriggerPlayerActivatables : MonoBehaviour
         }
     }
 
-    private void HandleCollision(GameObject obj) {
+    private void HandleCollision(GameObject obj, bool addToList = true) {
         PlayerActivatable[] playerActivatables = obj.GetComponents<PlayerActivatable>();
         if (playerActivatables == null) return;
         foreach (PlayerActivatable playerActivatable in playerActivatables) {

--- a/Assets/Core/InteractionBasic/TriggerPlayerActivatables.cs
+++ b/Assets/Core/InteractionBasic/TriggerPlayerActivatables.cs
@@ -6,7 +6,7 @@ public class TriggerPlayerActivatables : MonoBehaviour
 {
     private HashSet<PlayerActivatable> _previousHits = new HashSet<PlayerActivatable>();
     private HashSet<PlayerActivatable> _currentHits = new HashSet<PlayerActivatable>();
-
+    
     void Awake() {
         // Ensure a Rigidbody component is present and set it to kinematic
         Rigidbody rb = GetComponent<Rigidbody>();
@@ -16,7 +16,8 @@ public class TriggerPlayerActivatables : MonoBehaviour
         rb.isKinematic = true;
     }
 
-    void Update() {
+    void Update()
+    {
         if (_currentHits.Count == 0) return;
 
         foreach (PlayerActivatable playerActivatable in _currentHits) {
@@ -46,23 +47,27 @@ public class TriggerPlayerActivatables : MonoBehaviour
     }
 
     void OnTriggerExit(Collider other) {
-        PlayerActivatable[] playerActivatables = other.GetComponents<PlayerActivatable>();
-        if (playerActivatables != null) {
-            foreach (PlayerActivatable playerActivatable in playerActivatables) {
-                if (playerActivatable != null) {
-                    _currentHits.Remove(playerActivatable);
-                }
-            }
+        SolveExitState(other.gameObject);
+    }
+
+    private void SolveExitState(GameObject exitObject)
+    {
+        PlayerActivatable[] playerActivatables = exitObject.GetComponents<PlayerActivatable>();
+        if (playerActivatables == null) return;
+        foreach (PlayerActivatable playerActivatable in playerActivatables)
+        {
+            if (playerActivatable == null) continue;
+            _currentHits.Remove(playerActivatable);
+            _previousHits.Remove(playerActivatable);
         }
     }
 
     private void HandleCollision(GameObject obj) {
         PlayerActivatable[] playerActivatables = obj.GetComponents<PlayerActivatable>();
-        if (playerActivatables != null) {
-            foreach (PlayerActivatable playerActivatable in playerActivatables) {
-                if (playerActivatable != null && playerActivatable.canBeActivated) {
-                    _currentHits.Add(playerActivatable);
-                }
+        if (playerActivatables == null) return;
+        foreach (PlayerActivatable playerActivatable in playerActivatables) {
+            if (playerActivatable != null && playerActivatable.canBeActivated) {
+                _currentHits.Add(playerActivatable);
             }
         }
     }

--- a/Assets/Core/InteractionBasic/TriggerPlayerActivatables.cs
+++ b/Assets/Core/InteractionBasic/TriggerPlayerActivatables.cs
@@ -4,32 +4,52 @@ using UnityEngine;
 [RequireComponent(typeof(CharacterController), typeof(Rigidbody))]
 public class TriggerPlayerActivatables : MonoBehaviour
 {
-    private HashSet<PlayerActivatable> _previousHits = new HashSet<PlayerActivatable>();
-    private HashSet<PlayerActivatable> _currentHits = new HashSet<PlayerActivatable>();
-    
+    private HashSet<Collider> _previousHits = new HashSet<Collider>();
+    private HashSet<Collider> _currentHits = new HashSet<Collider>();
+
+    private CharacterController characterController;
+
     void Awake() {
-        // Ensure a Rigidbody component is present and set it to kinematic
-        Rigidbody rb = GetComponent<Rigidbody>();
-        if (!rb.isKinematic) return;
-        Debug.LogWarning($"{gameObject.name} Trigger Player Activatables is using a non-kinematic rigidbody. It will be forcibly set to kinematic.");
-        rb.isKinematic = true;
+        characterController = GetComponent<CharacterController>();
     }
 
-    void Update()
-    {
-        if (_currentHits.Count == 0) return;
-        foreach (PlayerActivatable playerActivatable in _currentHits) {
-            if (!_previousHits.Contains(playerActivatable)) {
-                playerActivatable.OnColliding();
+    void Update() {
+        QueryTriggers();
+    }
+
+    void QueryTriggers() {
+        float radius = characterController.radius;
+        float capsuleHeight = characterController.height;
+
+         // Calculate the top and bottom points of the capsule (relative to the current position)
+        Vector3 capsuleCenter = transform.position + characterController.center;
+        
+        // Adjust for the character controller's height and radius
+        float halfHeight = (capsuleHeight / 2) - radius;
+        
+        // Top and bottom points of the capsule
+        Vector3 point1 = capsuleCenter + Vector3.up * halfHeight;
+        Vector3 point2 = capsuleCenter - Vector3.up * halfHeight;
+
+        // Perform the CapsuleCastAll
+        Collider[] hitColliders = Physics.OverlapCapsule(point1, point2, radius);
+
+        // Check each hit collider to see if it has IsTrigger enabled
+        foreach (Collider hitCollider in hitColliders)
+        {
+            if (hitCollider.isTrigger)
+            {
+                _currentHits.Add(hitCollider);   
+                if (!_previousHits.Contains(hitCollider)) {
+                    HandleCollision(hitCollider.gameObject);
+                }
             }
         }
 
-        // Swap the sets to avoid reallocating memory
         _previousHits.Clear();
         var temp = _previousHits;
         _previousHits = _currentHits;
         _currentHits = temp;
-        _currentHits.Clear();
     }
 
     void OnControllerColliderHit(ControllerColliderHit hit)
@@ -37,46 +57,12 @@ public class TriggerPlayerActivatables : MonoBehaviour
         IterateOverPlayerActivatables(hit.gameObject.GetComponents<PlayerActivatable>());
     }
 
-    private void IterateOverPlayerActivatables(PlayerActivatable[] playerActivatables)
-    {
-        if (playerActivatables == null) return;
-        foreach (PlayerActivatable playerActivatable in playerActivatables) {
-            if (!_previousHits.Contains(playerActivatable)) {
-                playerActivatable.OnColliding();
-            }
-        }
-    }
 
-    void OnTriggerEnter(Collider other) {
-        HandleCollision(other.gameObject);
-    }
-
-    void OnTriggerStay(Collider other) {
-        HandleCollision(other.gameObject);
-    }
-
-    void OnTriggerExit(Collider other) {
-        SolveExitState(other.gameObject);
-    }
-
-    private void SolveExitState(GameObject exitObject)
-    {
-        PlayerActivatable[] playerActivatables = exitObject.GetComponents<PlayerActivatable>();
-        if (playerActivatables == null) return;
-        foreach (PlayerActivatable playerActivatable in playerActivatables)
-        {
-            if (playerActivatable == null) continue;
-            _currentHits.Remove(playerActivatable);
-            _previousHits.Remove(playerActivatable);
-        }
-    }
-
-    private void HandleCollision(GameObject obj, bool addToList = true) {
+    private void HandleCollision(GameObject obj) {
         PlayerActivatable[] playerActivatables = obj.GetComponents<PlayerActivatable>();
-        if (playerActivatables == null) return;
-        foreach (PlayerActivatable playerActivatable in playerActivatables) {
-            if (playerActivatable != null && playerActivatable.canBeActivated) {
-                _currentHits.Add(playerActivatable);
+        if (playerActivatables != null) {
+            foreach (PlayerActivatable playerActivatable in playerActivatables) {
+                playerActivatable.OnColliding();
             }
         }
     }

--- a/Assets/Interaction Scripts/DialogueTrigger.cs
+++ b/Assets/Interaction Scripts/DialogueTrigger.cs
@@ -1,19 +1,10 @@
 using UnityEngine;
 using Yarn.Unity;
 
-[RequireComponent(typeof(Collider))]
 public class DialogueTrigger : PlayerActivatable
 {
     public DialogueRunner dialogueRunner;
     public string dialogueNodeName;
-
-    private void Awake()
-    {
-        Collider selfCollider = GetComponent<Collider>();
-        if (selfCollider.isTrigger) return;
-        Debug.LogWarning($"{gameObject.name} Dialogue Trigger is using a non-trigger collider. It will be forcibly set to trigger.");
-        selfCollider.isTrigger = true;
-    }
 
     override protected void OnActivate()
     {    

--- a/Assets/Interaction Scripts/DialogueTrigger.cs
+++ b/Assets/Interaction Scripts/DialogueTrigger.cs
@@ -1,16 +1,19 @@
-using System.Collections;
-using System.Collections.Generic;
-using Unity.VisualScripting;
 using UnityEngine;
 using Yarn.Unity;
-using Yarn;
-using System.Reflection;
 
+[RequireComponent(typeof(Collider))]
 public class DialogueTrigger : PlayerActivatable
 {
     public DialogueRunner dialogueRunner;
-    
     public string dialogueNodeName;
+
+    private void Awake()
+    {
+        Collider selfCollider = GetComponent<Collider>();
+        if (selfCollider.isTrigger) return;
+        Debug.LogWarning($"{gameObject.name} Dialogue Trigger is using a non-trigger collider. It will be forcibly set to trigger.");
+        selfCollider.isTrigger = true;
+    }
 
     override protected void OnActivate()
     {    
@@ -22,7 +25,6 @@ public class DialogueTrigger : PlayerActivatable
         } else {
             Debug.LogWarning("DialogueRunner component not assigned!");
         }
-
     }
 
     override protected bool IsActivated() {
@@ -31,5 +33,4 @@ public class DialogueTrigger : PlayerActivatable
         }
         return base.IsActivated();
     }
-
 }


### PR DESCRIPTION
Clears the _previousHits HashSet on the exit command for triggers, properly allowing the same object to be triggered again once the object is not in contact with it anymore.
